### PR TITLE
Update seqdiag plugin to generate SVG

### DIFF
--- a/data/manual/Plugins/Diagram_Editor.txt
+++ b/data/manual/Plugins/Diagram_Editor.txt
@@ -25,3 +25,9 @@ digraph G {
 
 For full documentation of the script language see: http://www.graphviz.org/
 
+===== Options =====
+
+This plugin has the following options:
+
+* The option **Generate diagrams in SVG format** determines whether the diagrams will be generated in the SVG format. This is only enabled by default if your system supports it.
+

--- a/data/manual/Plugins/Sequence_Diagram_Editor.txt
+++ b/data/manual/Plugins/Sequence_Diagram_Editor.txt
@@ -16,6 +16,13 @@ To install the "seqdiag" tool, use ''easy_install'' or ''pip'':
 	''$ sudo pip seqdiag''
 
 
+===== Options =====
+
+This plugin has the following options:
+
+* The option **Generate diagrams in SVG format** determines whether the diagrams will be generated in the SVG format. This is only enabled by default if your system supports it.
+
+
 ===== Example =====
 
 For example a diagram like:

--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -364,7 +364,7 @@ def rotate_pixbuf(pixbuf):
 def supports_image_format(fmt):
 	'''Check if an image format is supported by GDK.
 	'''
-	return fmt in (f.name for f in GdkPixbuf.Pixbuf.get_formats())
+	return fmt in (f.get_name() for f in GdkPixbuf.Pixbuf.get_formats())
 
 def help_text_factory(text):
 	'''Create a label with an "info" icon in front of it. Intended for

--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -361,6 +361,11 @@ def rotate_pixbuf(pixbuf):
 		return pixbuf
 
 
+def supports_image_format(fmt):
+	'''Check if an image format is supported by GDK.
+	'''
+	return fmt in (f.name for f in GdkPixbuf.Pixbuf.get_formats())
+
 def help_text_factory(text):
 	'''Create a label with an "info" icon in front of it. Intended for
 	informational text in dialogs.

--- a/zim/plugins/__init__.py
+++ b/zim/plugins/__init__.py
@@ -30,7 +30,7 @@ to let plugins extend specific application objects.
 '''
 
 
-from gi.repository import GdkPixbuf, GObject
+from gi.repository import GObject
 import types
 import os
 import sys

--- a/zim/plugins/__init__.py
+++ b/zim/plugins/__init__.py
@@ -736,12 +736,6 @@ class PluginClass(ConnectorMixin):
 
 		return properties
 
-	def supports_image_format(self, fmt):
-		'''
-		Check if an image format is supported by GDK.
-		'''
-		return fmt in (f.name for f in GdkPixbuf.Pixbuf.get_formats())
-
 	@classmethod
 	def lookup_subclass(pluginklass, klass):
 		'''Returns first subclass of C{klass} found in the module of

--- a/zim/plugins/__init__.py
+++ b/zim/plugins/__init__.py
@@ -30,7 +30,7 @@ to let plugins extend specific application objects.
 '''
 
 
-from gi.repository import GObject
+from gi.repository import GdkPixbuf, GObject
 import types
 import os
 import sys
@@ -735,6 +735,12 @@ class PluginClass(ConnectorMixin):
 					pass
 
 		return properties
+
+	def supports_image_format(self, fmt):
+		'''
+		Check if an image format is supported by GDK.
+		'''
+		return fmt in (f.name for f in GdkPixbuf.Pixbuf.get_formats())
 
 	@classmethod
 	def lookup_subclass(pluginklass, klass):

--- a/zim/plugins/diagrameditor.py
+++ b/zim/plugins/diagrameditor.py
@@ -10,8 +10,8 @@ from zim.config import data_file
 from zim.applications import Application, ApplicationError
 
 
-# TODO put these commands in preferences
-dotcmd = ('dot', '-Tpng', '-o')
+def get_cmd(fmt):
+	return ('dot', f'-T{fmt}', '-o')
 
 
 class InsertDiagramPlugin(PluginClass):
@@ -27,9 +27,18 @@ This is a core plugin shipping with zim.
 		'author': 'Jaap Karssenberg',
 	}
 
+	@property
+	def plugin_preferences(self):
+		return (
+			'prefer_svg',
+			'bool',
+			_('Generate diagrams in SVG format'),
+			self.supports_image_format('svg'),
+		),
+
 	@classmethod
 	def check_dependencies(klass):
-		has_dotcmd = Application(dotcmd).tryexec()
+		has_dotcmd = Application(get_cmd('png')).tryexec()
 		return has_dotcmd, [("GraphViz", has_dotcmd, True)]
 
 
@@ -43,13 +52,23 @@ class BackwardDiagramImageObjectType(BackwardImageGeneratorObjectType):
 
 class DiagramGenerator(ImageGeneratorClass):
 
-	imagefile_extension = '.png'
+	@property
+	def _pref_format(self):
+		return 'svg' if self.plugin.preferences['prefer_svg'] else 'png'
+
+	@property
+	def imagefile_extension(self):
+		return '.' + self._pref_format
+
+	@property
+	def dotcmd(self):
+		return get_cmd(self._pref_format)
 
 	def __init__(self, plugin, notebook, page):
 		ImageGeneratorClass.__init__(self, plugin, notebook, page)
 		self.dotfile = TmpFile('diagram.dot')
 		self.dotfile.touch()
-		self.pngfile = LocalFile(self.dotfile.path[:-4] + '.png') # len('.dot') == 4
+		self.imgfile = LocalFile(self.dotfile.path[:-4] + self.imagefile_extension) # len('.dot') == 4
 
 	def generate_image(self, text):
 		# Write to tmp file
@@ -57,13 +76,13 @@ class DiagramGenerator(ImageGeneratorClass):
 
 		# Call GraphViz
 		try:
-			dot = Application(dotcmd)
-			dot.run((self.pngfile, self.dotfile))
+			dot = Application(self.dotcmd)
+			dot.run((self.imgfile, self.dotfile))
 		except ApplicationError:
 			return None, None # Sorry, no log
 		else:
-			if self.pngfile.exists():
-				return self.pngfile, None
+			if self.imgfile.exists():
+				return self.imgfile, None
 			else:
 				# When supplying a dot file with a syntax error, the dot command
 				# doesn't return an error code (so we don't raise
@@ -73,4 +92,4 @@ class DiagramGenerator(ImageGeneratorClass):
 
 	def cleanup(self):
 		self.dotfile.remove()
-		self.pngfile.remove()
+		self.imgfile.remove()

--- a/zim/plugins/diagrameditor.py
+++ b/zim/plugins/diagrameditor.py
@@ -9,6 +9,7 @@ from zim.plugins.base.imagegenerator import \
 
 from zim.newfs import LocalFile, TmpFile
 from zim.applications import Application, ApplicationError
+from zim.gui.widgets import supports_image_format
 
 logger = logging.getLogger('zim.plugins.diagrameditor')
 
@@ -29,15 +30,15 @@ This is a core plugin shipping with zim.
 		'author': 'Jaap Karssenberg',
 	}
 
-	@property
-	def plugin_preferences(self):
+	plugin_preferences = (
 		# key, type, label, default
-		return (
+		(
 			'prefer_svg',
 			'bool',
 			_('Generate diagrams in SVG format'),
-			self.supports_image_format('svg'),
+			supports_image_format('svg')
 		),
+	)
 
 	@classmethod
 	def check_dependencies(klass):

--- a/zim/plugins/sequencediagrameditor.py
+++ b/zim/plugins/sequencediagrameditor.py
@@ -2,6 +2,7 @@
 # Copyright 2011 Greg Warner <gdwarner@gmail.com>
 # (Pretty much copied from diagrameditor.py)
 
+import logging
 
 from zim.plugins import PluginClass
 from zim.plugins.base.imagegenerator import ImageGeneratorClass, BackwardImageGeneratorObjectType
@@ -9,6 +10,7 @@ from zim.plugins.base.imagegenerator import ImageGeneratorClass, BackwardImageGe
 from zim.newfs import LocalFile, TmpFile
 from zim.applications import Application, ApplicationError
 
+logger = logging.getLogger('zim.plugins.sequencediagrameditor')
 
 # TODO put these commands in preferences
 diagcmd = ('seqdiag', '-o')
@@ -68,6 +70,7 @@ class SequenceDiagramGenerator(ImageGeneratorClass):
 		# Write to tmp file
 		self.diagfile.write(text)
 		self.imgfile = LocalFile(self.diagfile.path[:-5] + self.imagefile_extension) # len('.diag') == 5
+		logger.debug('Writing diagram to temp file: %s', self.imgfile)
 
 		# Call seqdiag
 		try:
@@ -79,5 +82,8 @@ class SequenceDiagramGenerator(ImageGeneratorClass):
 			return self.imgfile, None
 
 	def cleanup(self):
-		self.diagfile.remove()
-		self.imgfile.remove()
+		try:
+			self.diagfile.remove()
+			self.imgfile.remove()
+		except AttributeError:
+			logger.debug('Closed dialog before generating image, nothing to remove')

--- a/zim/plugins/sequencediagrameditor.py
+++ b/zim/plugins/sequencediagrameditor.py
@@ -10,6 +10,7 @@ from zim.plugins.base.imagegenerator import \
 
 from zim.newfs import LocalFile, TmpFile
 from zim.applications import Application, ApplicationError
+from zim.gui.widgets import supports_image_format
 
 logger = logging.getLogger('zim.plugins.sequencediagrameditor')
 
@@ -29,15 +30,15 @@ It allows easy editing of sequence diagrams.
 		'author': 'Greg Warner',
 	}
 
-	@property
-	def plugin_preferences(self):
+	plugin_preferences = (
 		# key, type, label, default
-		return (
+		(
 			'prefer_svg',
 			'bool',
 			_('Generate diagrams in SVG format'),
-			self.supports_image_format('svg'),
+			supports_image_format('svg')
 		),
+	)
 
 	@classmethod
 	def check_dependencies(klass):

--- a/zim/plugins/sequencediagrameditor.py
+++ b/zim/plugins/sequencediagrameditor.py
@@ -11,7 +11,7 @@ from zim.applications import Application, ApplicationError
 
 
 # TODO put these commands in preferences
-diagcmd = ('seqdiag', '-o')
+diagcmd = ('seqdiag', '-T', 'svg', '-o')
 
 
 class InsertSequenceDiagramPlugin(PluginClass):
@@ -42,13 +42,13 @@ class BackwardSequenceDiagramImageObjectType(BackwardImageGeneratorObjectType):
 
 class SequenceDiagramGenerator(ImageGeneratorClass):
 
-	imagefile_extension = '.png'
+	imagefile_extension = '.svg'
 
 	def __init__(self, plugin, notebook, page):
 		ImageGeneratorClass.__init__(self, plugin, notebook, page)
 		self.diagfile = TmpFile('seqdiagram.diag')
 		self.diagfile.touch()
-		self.pngfile = LocalFile(self.diagfile.path[:-5] + '.png') # len('.diag') == 5
+		self.imgfile = LocalFile(self.diagfile.path[:-5] + self.imagefile_extension) # len('.diag') == 5
 
 	def generate_image(self, text):
 		# Write to tmp file
@@ -57,12 +57,12 @@ class SequenceDiagramGenerator(ImageGeneratorClass):
 		# Call seqdiag
 		try:
 			diag = Application(diagcmd)
-			diag.run((self.pngfile, self.diagfile))
+			diag.run((self.imgfile, self.diagfile))
 		except ApplicationError:
 			return None, None # Sorry, no log
 		else:
-			return self.pngfile, None
+			return self.imgfile, None
 
 	def cleanup(self):
 		self.diagfile.remove()
-		self.pngfile.remove()
+		self.imgfile.remove()


### PR DESCRIPTION
SVG images look significantly better in print and on the web. Have the sequence diagram editor generate SVG images instead of PNG.   

Tested on local and working fine.

Sample output files attached:

Before 
![seq](https://user-images.githubusercontent.com/54769/224324791-9e411337-1046-418e-afaf-eba09d45c0d9.png)

After
![seq](https://user-images.githubusercontent.com/54769/224324795-8b9f8b06-e30b-470b-ba10-34b2d4bdb504.svg)

